### PR TITLE
F4 - Scan subscribed clans for wars

### DIFF
--- a/lib/src/main/java/org/jprojects/lib/Main.java
+++ b/lib/src/main/java/org/jprojects/lib/Main.java
@@ -1,6 +1,11 @@
 package org.jprojects.lib;
 
+import java.util.Timer;
+
 import javax.security.auth.login.LoginException;
+
+import org.jprojects.lib.scheduled.WarChecker;
+import org.jprojects.scapi.JClashManager;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -11,6 +16,8 @@ public class Main {
 	private static String TOKEN = Token.getDiscordToken(); //Token hidden on git
 	
 	public static void main(String[] args) {
+		
+		//Start JDA
 		try {
 			jda = JDABuilder.createDefault(TOKEN)
 					.addEventListeners(MessageListener.getMessageListener())
@@ -24,6 +31,15 @@ public class Main {
 			System.out.println("Check your Asynch Thread usage..");
 			e.printStackTrace();
 		}
+		
+		//Start Clash API
+		JClashManager.getJClash();
+		
+		//Start WarChecker
+		Timer timer = new Timer(true); //Daemon
+		WarChecker warChecker = new WarChecker();
+		timer.schedule(warChecker, 1000, 1000 * 60 * 60 * 8); //every 1 minute for now -> every 8 hours in prod.
+		
 	}
 	
 	public static JDA getJDA() {

--- a/lib/src/main/java/org/jprojects/lib/commands/Command.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/Command.java
@@ -27,7 +27,6 @@ public class Command {
 			Command.getInstance(), 
 			Manage.getInstance(), 
 			Player.getInstance(),
-			War.getInstance(),
 			Help.getInstance(),
 			Subscribe.getInstance(),
 			Unsubscribe.getInstance(),

--- a/lib/src/main/java/org/jprojects/lib/commands/War.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/War.java
@@ -10,6 +10,7 @@ import org.jprojects.lib.ServerData;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
+//Retired class
 public class War extends Command {
 	
 	private final static int FIRST_REMINDER_DELTA = 90 * 60; //90 minutes
@@ -109,28 +110,12 @@ public class War extends Command {
 			}			
 			
 			//5. Schedule the message.
-			WarRunner runner = new WarRunner(e.getGuild().getIdLong(), mc, new String[] {sd.getWarReminder(1), sd.getWarReminder(2)},e.getMessage().getMentionedUsers());
-			ScheduledExecutorService ses = Executors.newScheduledThreadPool(1);
-			ses.schedule(runner, Math.max(timeSecs-FIRST_REMINDER_DELTA, 1), TimeUnit.SECONDS);
-			ses.schedule(runner, Math.max(timeSecs-SECOND_REMINDER_DELTA,2), TimeUnit.SECONDS);
+			//WarRunner runner = new WarRunner(e.getGuild().getIdLong(), mc, new String[] {sd.getWarReminder(1), sd.getWarReminder(2)},e.getMessage().getMentionedUsers());
+			//ScheduledExecutorService ses = Executors.newScheduledThreadPool(1);
+			//ses.schedule(runner, Math.max(timeSecs-FIRST_REMINDER_DELTA, 1), TimeUnit.SECONDS);
+			//ses.schedule(runner, Math.max(timeSecs-SECOND_REMINDER_DELTA,2), TimeUnit.SECONDS);
 			
 			e.getChannel().sendMessage("Great! I'll remind everyone a couple times before the end of the war!").queue();
-			return;
-			
-		/*
-		 * WAR ATTACK
-		 * $ WAR ATTACK
-		 * Signal that you used an attack in war. if you use two attacks, you don't need to 
-		 */
-		} else if (command[1].equalsIgnoreCase("Attack")) {
-			
-			List<WarRunner> clanWars = WarRunner.getRunnersForServer(e.getGuild().getIdLong());
-			int ctr = 0;
-			for (WarRunner wr : clanWars)
-				if (wr.attack(e.getAuthor()))
-					ctr++;
-			
-			e.getChannel().sendMessage("Found you in " + ctr + " clan" + (ctr == 0 ? "s" : (ctr == 1 ? " and noted that you used an attack." : "s, and marked each one with one attack."))).queue();
 			return;
 			
 		} else if (command[1].equalsIgnoreCase("help")) {

--- a/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
@@ -6,18 +6,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jprojects.lib.Main;
+import org.jprojects.lib.database.DiscordToClashDF;
+import org.jprojects.scapi.ScapiWarAF;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 
 public class WarRunner implements Runnable {
 	public static HashMap<Long, List<WarRunner>> warRunners = new HashMap<Long, List<WarRunner>>();
 	
 	String[] msgs;
-	List<User> users;
 	int ctr;
-	MessageChannel channel;
+	long channel = 0;
 	boolean shouldRun = true;
 	Long guildID;
+	String clanID;
 	
 	public static List<WarRunner> getRunnersForServer(Long guild) {
 		synchronized (warRunners) {
@@ -25,15 +33,12 @@ public class WarRunner implements Runnable {
 		}
 	}
 	
-	public WarRunner(Long guild, MessageChannel channel, String[] messages, List<User> userList) {
+	public WarRunner(Long guild, String clan, long channel, String[] messages) {
 		msgs = messages;
 		ctr = 0;
 		this.channel = channel;
 		guildID = guild;
-		
-		users = new ArrayList<User>();
-		users.addAll(userList);
-		users.addAll(userList); //two attacks each.
+		clanID = clan;
 		
 		//update the list of warRunners.
 		synchronized (warRunners) {
@@ -43,39 +48,51 @@ public class WarRunner implements Runnable {
 		}
 	}
 	
-	public boolean attack(User user) {
-		synchronized (warRunners) {
-			return users.remove(user);
-		}
-	}
-	
 	@Override
 	public void run() {
 		synchronized (warRunners) {
-			//If we run into an invalid configuration at any point, remove from list of warRunners.
 			
-			//if message send is in some way invalid, don't send anything.
-			if (msgs.length == 0 || !shouldRun || channel == null) {
+			//if we shouldn't run, don't
+			if (ctr >= msgs.length || !shouldRun) {
 				//invalid configuration
 				warRunners.getOrDefault(guildID, new ArrayList<WarRunner>()).remove(this);
 				return;
 			}
 			
-			//if we've gone through all the messages, we're done.
-			if (ctr > msgs.length) {
-				warRunners.getOrDefault(guildID, new ArrayList<WarRunner>()).remove(this);
-				return;
+			
+			//Get all users that are discord members of <guildId> AND clanmembers of <clanId> AND have notifs enabled AND have not attacked.
+			
+			//clashers that have not attacked
+			List<String> clashUserIds = ScapiWarAF.getInstance().hasNotAttacked(clanID);
+			
+			//fish out the guild
+			Guild guild = Main.getJDA().getGuildById(guildID);
+			guild.getMemberById(channel);
+			guild.getDefaultChannel();
+			
+			//convert clashers to userIds
+			Set<String> discordUserIds = new HashSet<String>();
+			for (String clashUser : clashUserIds) {
+				discordUserIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getSubscribersForClashID(clashUser));
 			}
 			
-			//build message
-			StringBuilder sb = new StringBuilder();
-			Set<User> yetToAttack = new HashSet<User>(users);
-			for (User user : yetToAttack)
-					sb.append(user.getAsMention() + " ");
-			sb.append(msgs[ctr++]);
+			//convert IDs to members
+			Set<Member> members = new HashSet<Member>();
+			for (String discordUser : discordUserIds) {
+				Member newMember = guild.getMemberById(discordUser);
+				if (newMember != null)
+					members.add(newMember);
+			}
 			
-			//send message
-			channel.sendMessage(sb.toString()).queue();
+			TextChannel c = guild.getTextChannelById(channel);
+			if (c == null)
+				c = guild.getDefaultChannel();
+			
+			
+			//send an individual ping to each user
+			for (Member pingMe : members) {
+				c.sendMessage(pingMe.getAsMention() + " " + msgs[ctr++]).queue();
+			}
 		}
 	}
 	

--- a/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
+++ b/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
@@ -1,0 +1,84 @@
+package org.jprojects.lib.scheduled;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.jprojects.lib.ServerData;
+import org.jprojects.lib.commands.WarRunner;
+import org.jprojects.lib.database.DiscordToClashDF;
+import org.jprojects.lib.util.Pair;
+import org.jprojects.scapi.ScapiWarAF;
+
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+public class WarChecker extends TimerTask {
+	private final static int FIRST_REMINDER_DELTA = (25 * 60) + 32400; //90 minutes
+	private final static int SECOND_REMINDER_DELTA = 30 * 60; //30 minutes
+	
+	//Map clash's clan ID to last known _end_ time of war.
+	private static Map<String, String> scheduled = new ConcurrentHashMap<String, String>();
+	
+	//TODO find a way to get this to run for CWL
+	public void run() {
+		System.out.println("Checking for wars...");
+		System.out.println((new Date()).toString());
+		
+		//Get list of subscriptions
+		List<Pair<String, String>> pairs = DiscordToClashDF.getDiscordtoClashDF().getDiscordClashServerPairs();
+		
+		//change to set of clan IDs
+		Set<String> clanIds = new HashSet<String>();
+		for (Pair<String, String> pair : pairs) {
+			clanIds.add(pair.getSecond());
+		}
+		
+		//For each ID, 
+		for (String clanId : clanIds) {
+			System.out.println("Checking " + clanId + "... ");
+			//check if there is an ongoing war.
+			if (ScapiWarAF.getInstance().isInWar(clanId)) {
+				//if in a war state, see if we know about the end date.
+				String knownEndTime = scheduled.getOrDefault(clanId, "");
+				if (ScapiWarAF.getInstance().getWarEndTime(clanId) == knownEndTime)
+					continue;
+				
+				//if it's a new end date, we need to set some reminders.
+				long timeSecs = ScapiWarAF.getInstance().getRemainingWarTimeSeconds(clanId);
+				
+				//get list of Discord Servers for clanId:
+				Set<String> discordServers = new HashSet<String>();
+				for (Pair<String, String> pair : pairs) {
+					if (clanId.equals(pair.getSecond()))
+						discordServers.add(pair.getFirst());
+				}
+				//4. craft a message.
+				for (String server : discordServers) {
+					ServerData sd = ServerData.getServer(Long.parseLong(server));
+						
+					
+					//5. Schedule the message.
+					System.out.println(" * Creating a WarRunner to run first in " + Math.max(timeSecs-FIRST_REMINDER_DELTA, 1) + " and then " + Math.max(timeSecs-SECOND_REMINDER_DELTA,2) + " seconds.");
+					WarRunner runner = new WarRunner(Long.parseLong(server), clanId, sd.getDefaultChannel(), new String[] {sd.getWarReminder(1), sd.getWarReminder(2)});
+					ScheduledExecutorService ses = Executors.newScheduledThreadPool(1);
+					ses.schedule(runner, Math.max(timeSecs-FIRST_REMINDER_DELTA, 1), TimeUnit.SECONDS);
+					ses.schedule(runner, Math.max(timeSecs-SECOND_REMINDER_DELTA,2), TimeUnit.SECONDS);
+				}
+			}
+		}
+		
+		
+		//If clan is in a war state and end time not in scheduled map,
+		//schedule new runners.
+		
+		
+	}
+}

--- a/lib/src/main/java/org/jprojects/lib/util/Pair.java
+++ b/lib/src/main/java/org/jprojects/lib/util/Pair.java
@@ -1,0 +1,28 @@
+package org.jprojects.lib.util;
+
+public class Pair<T,V> {
+	
+	private T object1;
+	private V object2;
+	
+	public Pair(T first, V second) {
+		this.object1 = first;
+		this.object2 = second;
+	}
+	
+	public void setFirst(T first) {
+		this.object1 = first;
+	}
+	
+	public T getFirst() {
+		return object1;
+	}
+	
+	public void setSecond(V second) {
+		this.object2 = second;
+	}
+	
+	public V getSecond() {
+		return object2;
+	}
+}

--- a/lib/src/main/java/org/jprojects/scapi/JClashManager.java
+++ b/lib/src/main/java/org/jprojects/scapi/JClashManager.java
@@ -18,8 +18,8 @@ private static JClashManager singleton = new JClashManager();
 				e.printStackTrace();
 				System.exit(-1);
 			}
+			System.out.println("JClash initialized successfully.");
 		}
-		System.out.println("JClash initialized successfully.");
 		return clash;
 			
 	}

--- a/lib/src/main/java/org/jprojects/scapi/ScapiPlayerAF.java
+++ b/lib/src/main/java/org/jprojects/scapi/ScapiPlayerAF.java
@@ -19,7 +19,7 @@ public class ScapiPlayerAF {
 	//Get player name or NULL if player does not exist
 	public String getPlayerNameFromTag(String playerTag)  {
 		//quick fail for simple cases:
-		if( playerTag.length() != 9 
+		if( playerTag.length() < 2 
 				||  playerTag.charAt(0) != '#')
 			return null;
 		try {

--- a/lib/src/main/java/org/jprojects/scapi/ScapiWarAF.java
+++ b/lib/src/main/java/org/jprojects/scapi/ScapiWarAF.java
@@ -38,9 +38,14 @@ import org.jprojects.lib.database.DiscordToClashDF;
 
 //Base Facade to connect to 
 public class ScapiWarAF {
+	private ScapiWarAF() {
+	}
 	
-	public static void main(String[] args) {
-    }
+	private static ScapiWarAF instance = new ScapiWarAF();
+	public static ScapiWarAF getInstance() {			
+		return instance;
+	}
+	
 	/*
 	public static void main(String[] args) {
 		new ScapiWarBF().hasNotAttacked("#UYOPRJJR");
@@ -62,6 +67,20 @@ public class ScapiWarAF {
 			e.printStackTrace();
 		}
 		return false;
+	}
+	
+	public String getWarEndTime(String clanTag) {
+		try {
+			CompletableFuture<WarInfo> future = JClashManager.getJClash().getCurrentWar(clanTag);
+			WarInfo info = future.get();
+			Date now = new Date();
+			return info.getEndTime();
+			
+		} catch (IOException | InterruptedException | ExecutionException e) {
+			System.out.println("Error getting current war for " + clanTag);
+			e.printStackTrace();
+			return null;
+		}
 	}
 	
 	public boolean isInWar(String clanTag) {
@@ -130,7 +149,19 @@ public class ScapiWarAF {
 		return userIds;
 	}
 	
-	public int getRemainingWarTimeSeconds() {
-		return -1;
+	public long getRemainingWarTimeSeconds(String clanTag) {
+		try {
+			CompletableFuture<WarInfo> future = JClashManager.getJClash().getCurrentWar(clanTag);
+			WarInfo info = future.get();
+			Date then = info.getEndTimeAsDate();
+			Date now = new Date();
+			long difference = then.getTime() - now.getTime();
+			return difference / 1000;
+			
+		} catch (IOException | InterruptedException | ExecutionException | ParseException e) {
+			System.out.println("Error getting current war for " + clanTag);
+			e.printStackTrace();
+			return -1;
+		}
 	}
 }


### PR DESCRIPTION
First, removed the old code that managed user-input of new wars. This took out just about the whole war class, but going to keep the file in just a bit longer.

Second, added a scheduled task that runs every eight hours looking for new clan wars on all clans that are subscribed. Might switch this to four or twelve hours, depending on how things go.

some more work needs to be done to get the new WarRunners to send actual pings to end users.