### PR TITLE
F9 Get WarRunner to Ping Users

### DIFF
--- a/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
@@ -79,7 +79,8 @@ public class WarRunner implements Runnable {
 			//convert IDs to members
 			Set<Member> members = new HashSet<Member>();
 			for (String discordUser : discordUserIds) {
-				Member newMember = guild.getMemberById(discordUser);
+				Member newMember;
+				newMember = guild.retrieveMemberById(discordUser).complete();
 				if (newMember != null)
 					members.add(newMember);
 			}
@@ -91,8 +92,9 @@ public class WarRunner implements Runnable {
 			
 			//send an individual ping to each user
 			for (Member pingMe : members) {
-				c.sendMessage(pingMe.getAsMention() + " " + msgs[ctr++]).queue();
+				c.sendMessage(pingMe.getAsMention() + " " + msgs[ctr]).queue();
 			}
+			ctr++;
 		}
 	}
 	

--- a/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
+++ b/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
@@ -21,7 +21,7 @@ import org.jprojects.scapi.ScapiWarAF;
 import net.dv8tion.jda.api.entities.MessageChannel;
 
 public class WarChecker extends TimerTask {
-	private final static int FIRST_REMINDER_DELTA = (25 * 60) + 32400; //90 minutes
+	private final static int FIRST_REMINDER_DELTA = 90 * 60; //90 minutes
 	private final static int SECOND_REMINDER_DELTA = 30 * 60; //30 minutes
 	
 	//Map clash's clan ID to last known _end_ time of war.

--- a/lib/src/main/java/org/jprojects/scapi/ScapiClanAF.java
+++ b/lib/src/main/java/org/jprojects/scapi/ScapiClanAF.java
@@ -20,7 +20,7 @@ public class ScapiClanAF {
 	//Get player name or NULL if player does not exist
 	public String getClanNameFromTag(String clanTag)  {
 		//quick fail for simple cases:
-		if( clanTag.length() != 9 
+		if( clanTag.length() < 2 
 				||  clanTag.charAt(0) != '#')
 			return null;
 		try {

--- a/lib/src/main/java/org/jprojects/scapi/ScapiWarAF.java
+++ b/lib/src/main/java/org/jprojects/scapi/ScapiWarAF.java
@@ -87,12 +87,15 @@ public class ScapiWarAF {
 		try {
 			CompletableFuture<WarInfo> future = JClashManager.getJClash().getCurrentWar(clanTag);
 			WarInfo info = future.get();
+			if (info.getState().equals("notInWar"))
+				return false;
 			Date now = new Date();
 			return (info.getPreparationStartTimeAsDate().before(now) && info.getEndTimeAsDate().after(now));
 			
-		} catch (IOException | InterruptedException | ExecutionException | ParseException e) {
+		} catch (Exception e) {
 			System.out.println("Error getting current war for " + clanTag);
 			e.printStackTrace();
+			System.out.println("rip.");
 			return false;
 		}
 	}
@@ -135,7 +138,7 @@ public class ScapiWarAF {
 			//if before war day or user has not attacked:
 			for (ClanWarMember c : potential) {
 				int attacksPerformed = c.getAttacks() == null ? 0 : c.getAttacks().size();
-				if (info.getStartTimeAsDate().before(now) || attacksPerformed < 2) {
+				if (info.getStartTimeAsDate().after(now) || attacksPerformed < 2) {
 					System.out.println(c.getName() + " has " + (2 - attacksPerformed) + " attacks left. ");
 					userIds.add(c.getTag());
 				} else {


### PR DESCRIPTION
get the war runner class to actually ping users at the time it is called, instead of erroring out.

also fixed the time to call (first delta) in the warChecker class from a test value to a production-ready value.