### PR TITLE
F23: Make subscriptions server-specific

### DIFF
--- a/lib/src/main/java/org/jprojects/lib/commands/Subscribe.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/Subscribe.java
@@ -66,15 +66,17 @@ public class Subscribe extends Command {
 		String discordID = e.getMessage().getMentionedUsers().get(0).getId();
 		String discordName = e.getMessage().getMentionedMembers().get(0).getEffectiveName();
 		String clashID = command[command.length-1];
-
+		String discordServer = e.getGuild().getId();
 		if ((clashName = ScapiPlayerAF.getInstance().getPlayerNameFromTag(clashID) ) == null ) {
 			e.getChannel().sendMessage("The clash player tag " + clashID + " appears to be invalid.").queue();
 			return;
 		}
 		
-		boolean success = DiscordToClashDF.getDiscordtoClashDF().addSubscriptionToDiscordUser(discordID, clashID);
-		if (success)
+		int successCode = DiscordToClashDF.getDiscordtoClashDF().addSubscriberByDiscordServerAndUser(discordServer, discordID, clashID);
+		if (successCode == DiscordToClashDF.SQL_OK)
 			e.getChannel().sendMessage("Great! " + discordName + " is now subscribed to notifications for Clash player '" + clashName + "'").queue();
+		else if (successCode == DiscordToClashDF.SQL_FAILED_RECORD_EXISTS)
+			e.getChannel().sendMessage("Hey, " + discordName + " is already subscribed to that clash account!").queue();
 		else
 			e.getChannel().sendMessage("Uh-oh, something went wrong, but I'm not quite sure what. If this happens again, contact the dev at dev@jprojects.org with the command you tried to use.").queue();
 	}
@@ -95,9 +97,11 @@ public class Subscribe extends Command {
 		}
 		
 		//well, we have permission. we have a valid clan. we have a discord. log it.
-		boolean success = DiscordToClashDF.getDiscordtoClashDF().AddClanToDiscordServer(discordID, clashID);
-		if (success)
+		int successCode = DiscordToClashDF.getDiscordtoClashDF().addClashServerToDiscordServer(discordID, clashID);
+		if (successCode == DiscordToClashDF.SQL_OK)
 			e.getChannel().sendMessage("Great! This discord server is now subscribed to notifications for the clan '" + clashName + "'").queue();
+		else if (successCode == DiscordToClashDF.SQL_FAILED_RECORD_EXISTS)
+			e.getChannel().sendMessage("Hey, this server is already subscribed to " + clashName + "!").queue();
 		else
 			e.getChannel().sendMessage("Uh-oh, something went wrong, but I'm not quite sure what. If this happens again, contact the dev at dev@jprojects.org with the command you tried to use.").queue();
 	}

--- a/lib/src/main/java/org/jprojects/lib/commands/Unsubscribe.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/Unsubscribe.java
@@ -70,10 +70,12 @@ public class Unsubscribe extends Command {
 		}
 		
 		String discordName = e.getMessage().getMentionedMembers().get(0).getEffectiveName();
-		
-		boolean success = DiscordToClashDF.getDiscordtoClashDF().removeSubscriptionFromDiscordUser(discordID, clashID);
-		if (success)
+		String discordServer = e.getGuild().getId();
+		int successCode = DiscordToClashDF.getDiscordtoClashDF().removeSubscriberByDiscordServerAndUser(discordServer, discordID, clashID);
+		if (successCode == DiscordToClashDF.SQL_OK)
 			e.getChannel().sendMessage("Great! " + discordName + " is now unsubscribed to notifications for Clash player '" + clashName + "'").queue();
+		else if (successCode == DiscordToClashDF.SQL_FAILED_NOT_FOUND)
+			e.getChannel().sendMessage("Hmm..." + discordName + " was not subscribed to clash account '" + clashName + "'. I guess that makes my job easier, though.").queue();
 		else
 			e.getChannel().sendMessage("Uh-oh, something went wrong, but I'm not quite sure what. If this happens again, contact the dev at dev@jprojects.org with the command you tried to use.").queue();
 	}
@@ -94,9 +96,11 @@ public class Unsubscribe extends Command {
 		}
 		
 		//well, we have permission. we have a valid clan. we have a discord. log it.
-		boolean success = DiscordToClashDF.getDiscordtoClashDF().removeClanFromDiscordServer(discordID, clashID);
-		if (success)
+		int successCode = DiscordToClashDF.getDiscordtoClashDF().removeClashServerFromDiscordServer(discordID, clashID);
+		if (successCode == DiscordToClashDF.SQL_OK)
 			e.getChannel().sendMessage("Great! This discord server is now unsubscribed to notifications for the clan '" + clashName + "'").queue();
+		else if (successCode == DiscordToClashDF.SQL_FAILED_NOT_FOUND)
+			e.getChannel().sendMessage("Hmm, this discord server was not subscribed to that clan. I guess that makes my job easier, though.").queue();
 		else
 			e.getChannel().sendMessage("Uh-oh, something went wrong, but I'm not quite sure what. If this happens again, contact the dev at dev@jprojects.org with the command you tried to use.").queue();
 	}

--- a/lib/src/main/java/org/jprojects/lib/commands/War.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/War.java
@@ -67,7 +67,7 @@ public class War extends Command {
 				clanIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getClansByDiscordServer(e.getGuild().getId()));
 			} else {
 				//Check if clan is subscribed to:
-				if( DiscordToClashDF.getDiscordtoClashDF().serverRelationshipExists(e.getGuild().getId(),command[2]) )
+				if( DiscordToClashDF.getDiscordtoClashDF().recordExists(e.getGuild().getId(), null, command[2], null) == DiscordToClashDF.SQL_OK)
 					clanIds.add(command[2]);
 				else {
 					e.getChannel().sendMessage("It looks like you entered an invalid clan.").queue();
@@ -89,7 +89,7 @@ public class War extends Command {
 				//convert clashers to userIds
 				Set<String> discordUserIds = new HashSet<String>();
 				for (String clashUser : clashUserIds) {
-					discordUserIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getSubscribersForClashID(clashUser));
+					discordUserIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getUsersSubscribedToClashAccountOnServer(clashUser, guild.getId()));
 				}
 				
 				//convert IDs to members
@@ -112,7 +112,7 @@ public class War extends Command {
 					boolean plural = false;
 					StringBuilder sb = new StringBuilder();
 					for (String clashUser : clashUserIds) {
-						if (DiscordToClashDF.getDiscordtoClashDF().subscriberRelationshipExists(pingMe.getUser().getId(), clashUser) || DiscordToClashDF.getDiscordtoClashDF().ownerRelationshipExists(pingMe.getUser().getId(), clashUser)) {
+						if (DiscordToClashDF.getDiscordtoClashDF().recordExists(pingMe.getGuild().getId(), pingMe.getUser().getId(), clashUser, null) == DiscordToClashDF.SQL_OK || DiscordToClashDF.getDiscordtoClashDF().recordExists(pingMe.getGuild().getId(), pingMe.getUser().getId(), clashUser, "O") == DiscordToClashDF.SQL_OK) {
 							if (sb.length() > 0) {
 								plural = true;
 								sb.append(", ");

--- a/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
+++ b/lib/src/main/java/org/jprojects/lib/commands/WarRunner.java
@@ -73,7 +73,7 @@ public class WarRunner implements Runnable {
 			//convert clashers to userIds
 			Set<String> discordUserIds = new HashSet<String>();
 			for (String clashUser : clashUserIds) {
-				discordUserIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getSubscribersForClashID(clashUser));
+				discordUserIds.addAll(DiscordToClashDF.getDiscordtoClashDF().getUsersSubscribedToClashAccountOnServer(clashUser, guild.getId()));
 			}
 			
 			//convert IDs to members

--- a/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
+++ b/lib/src/main/java/org/jprojects/lib/scheduled/WarChecker.java
@@ -48,8 +48,10 @@ public class WarChecker extends TimerTask {
 			if (ScapiWarAF.getInstance().isInWar(clanId)) {
 				//if in a war state, see if we know about the end date.
 				String knownEndTime = scheduled.getOrDefault(clanId, "");
-				if (ScapiWarAF.getInstance().getWarEndTime(clanId) == knownEndTime)
+				String endTime = ScapiWarAF.getInstance().getWarEndTime(clanId);
+				if (knownEndTime.equals(endTime))
 					continue;
+				scheduled.put(clanId, endTime);
 				
 				//if it's a new end date, we need to set some reminders.
 				long timeSecs = ScapiWarAF.getInstance().getRemainingWarTimeSeconds(clanId);


### PR DESCRIPTION
Database change to add an extra field that allows subscriptions to be server-specific. This is the cleaner way to do subscriptions to make sure users in multiple discords have as much control as possible over their subscriptions. It will also allow us to refactor the WarChecker/Runner code in the near future to run more efficiently and look cleaner.

Reworked what methods were available in the DiscordToClashDF